### PR TITLE
Add 1.9.0 SteamSharedLibraryLoader as SteamLibraryLoaderLegacy

### DIFF
--- a/loader/legacy/pom.xml
+++ b/loader/legacy/pom.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.code-disaster.steamworks4j</groupId>
+	<artifactId>steamworks4j-legacy</artifactId>
+	<version>1.10.0-SNAPSHOT</version>
+
+	<packaging>jar</packaging>
+
+	<name>Steam API Java Wrapper - Legacy library loader</name>
+	<description>Java wrapper to access the Steamworks API.</description>
+	<url>http://github.com/code-disaster/steamworks4j</url>
+
+	<issueManagement>
+		<url>http://github.com/code-disaster/steamworks4j/issues</url>
+	</issueManagement>
+
+	<licenses>
+		<license>
+			<name>MIT License</name>
+			<url>http://www.opensource.org/licenses/mit-license.php</url>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<name>Daniel Ludwig</name>
+			<email>codi@code-disaster.com</email>
+			<timezone>+1</timezone>
+		</developer>
+	</developers>
+
+	<scm>
+		<connection>scm:git:https://github.com/code-disaster/steamworks4j.git</connection>
+		<developerConnection>scm:git:https://github.com/code-disaster/steamworks4j.git</developerConnection>
+		<url>http://github.com/code-disaster/steamworks4j</url>
+	</scm>
+
+	<profiles>
+		<profile>
+			<id>release</id>
+			<distributionManagement>
+				<repository>
+					<id>ossrh</id>
+					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+				</repository>
+			</distributionManagement>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.0.1</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>snapshot</id>
+			<distributionManagement>
+				<snapshotRepository>
+					<id>ossrh</id>
+					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+				</snapshotRepository>
+			</distributionManagement>
+		</profile>
+		<profile>
+			<id>java-8-api</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<maven.compiler.release>8</maven.compiler.release>
+			</properties>
+		</profile>
+	</profiles>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.code-disaster.steamworks4j</groupId>
+			<artifactId>steamworks4j</artifactId>
+			<version>1.10.0-SNAPSHOT</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>3.3.0</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.11.0</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.3.0</version>
+				<configuration>
+					<excludeResources>true</excludeResources>
+				</configuration>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.5.0</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<doclint>none</doclint>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/loader/legacy/src/main/java/com/codedisaster/steamworks/SteamLibraryLoaderLegacy.java
+++ b/loader/legacy/src/main/java/com/codedisaster/steamworks/SteamLibraryLoaderLegacy.java
@@ -1,0 +1,273 @@
+package com.codedisaster.steamworks;
+
+import java.io.*;
+import java.util.UUID;
+
+public class SteamLibraryLoaderLegacy implements SteamLibraryLoader {
+
+	enum PLATFORM {
+		Windows,
+		Linux,
+		MacOS
+	}
+
+	private String libraryPath;
+
+	private static final PLATFORM OS;
+	private static final boolean IS_64_BIT;
+
+	private static final String SHARED_LIBRARY_EXTRACT_DIRECTORY = System.getProperty(
+			"com.codedisaster.steamworks.SharedLibraryExtractDirectory", "steamworks4j");
+
+	private static final String SHARED_LIBRARY_EXTRACT_PATH = System.getProperty(
+			"com.codedisaster.steamworks.SharedLibraryExtractPath", null);
+
+	private static final String SDK_REDISTRIBUTABLE_BIN_PATH = System.getProperty(
+			"com.codedisaster.steamworks.SDKRedistributableBinPath", "sdk/redistributable_bin");
+
+	private static final String SDK_LIBRARY_PATH = System.getProperty(
+			"com.codedisaster.steamworks.SDKLibraryPath", "sdk/public/steam/lib");
+
+	static final boolean DEBUG = Boolean.parseBoolean(System.getProperty(
+			"com.codedisaster.steamworks.Debug", "false"));
+
+	static {
+		String osName = System.getProperty("os.name");
+		String osArch = System.getProperty("os.arch");
+
+		if (osName.contains("Windows")) {
+			OS = PLATFORM.Windows;
+		} else if (osName.contains("Linux")) {
+			OS = PLATFORM.Linux;
+		} else if (osName.contains("Mac")) {
+			OS = PLATFORM.MacOS;
+		} else {
+			throw new RuntimeException("Unknown host architecture: " + osName + ", " + osArch);
+		}
+
+		IS_64_BIT = osArch.equals("amd64") || osArch.equals("x86_64");
+	}
+
+	private static String getPlatformLibName(String libName) {
+		switch (OS) {
+			case Windows:
+				return libName + (IS_64_BIT ? "64" : "") + ".dll";
+			case Linux:
+				return "lib" + libName + ".so";
+			case MacOS:
+				return "lib" + libName + ".dylib";
+		}
+
+		throw new RuntimeException("Unknown host architecture");
+	}
+
+	static String getSdkRedistributableBinPath() {
+		File path;
+		switch (OS) {
+			case Windows:
+				path = new File(SDK_REDISTRIBUTABLE_BIN_PATH, IS_64_BIT ? "win64" : "");
+				break;
+			case Linux:
+				path = new File(SDK_REDISTRIBUTABLE_BIN_PATH, "linux64");
+				break;
+			case MacOS:
+				path = new File(SDK_REDISTRIBUTABLE_BIN_PATH, "osx");
+				break;
+			default:
+				return null;
+		}
+
+		return path.exists() ? path.getPath() : null;
+	}
+
+	static String getSdkLibraryPath() {
+		File path;
+		switch (OS) {
+			case Windows:
+				path = new File(SDK_LIBRARY_PATH, IS_64_BIT ? "win64" : "win32");
+				break;
+			case Linux:
+				path = new File(SDK_LIBRARY_PATH, "linux64");
+				break;
+			case MacOS:
+				path = new File(SDK_LIBRARY_PATH, "osx");
+				break;
+			default:
+				return null;
+		}
+
+		return path.exists() ? path.getPath() : null;
+	}
+
+	@Override
+	public void setLibraryPath(String libraryPath) {
+		this.libraryPath = libraryPath;
+	}
+
+	@Override
+	public boolean loadLibrary(String libraryName) {
+		try {
+			String librarySystemName = getPlatformLibName(libraryName);
+
+			File librarySystemPath = discoverExtractLocation(
+					SHARED_LIBRARY_EXTRACT_DIRECTORY + "/" + Version.getVersion(), librarySystemName);
+
+			if (libraryPath == null) {
+				// extract library from resource
+				extractLibrary(librarySystemPath, librarySystemName);
+			} else {
+				// read library from given path
+				File librarySourcePath = new File(libraryPath, librarySystemName);
+
+				if (OS != PLATFORM.Windows) {
+					// on MacOS & Linux, "extract" (copy) from source location
+					extractLibrary(librarySystemPath, librarySourcePath);
+				} else {
+					// on Windows, load the library from the source location
+					librarySystemPath = librarySourcePath;
+				}
+			}
+
+			String absolutePath = librarySystemPath.getCanonicalPath();
+			System.load(absolutePath);
+		} catch (IOException e) {
+			return false;
+		}
+		return true;
+	}
+
+	private static void extractLibrary(File librarySystemPath, String librarySystemName) throws IOException {
+		extractLibrary(librarySystemPath,
+				SteamLibraryLoaderLegacy.class.getResourceAsStream("/" + librarySystemName));
+	}
+
+	private static void extractLibrary(File librarySystemPath, File librarySourcePath) throws IOException {
+		extractLibrary(librarySystemPath, new FileInputStream(librarySourcePath));
+	}
+
+	private static void extractLibrary(File librarySystemPath, InputStream input) throws IOException {
+		if (input != null) {
+			try (FileOutputStream output = new FileOutputStream(librarySystemPath)) {
+				byte[] buffer = new byte[4096];
+				while (true) {
+					int length = input.read(buffer);
+					if (length == -1) break;
+					output.write(buffer, 0, length);
+				}
+				output.close();
+			} catch (IOException e) {
+				/*
+					Extracting the library may fail, for example because 'nativeFile' already exists and is in
+					use by another process. In this case, we fail silently and just try to load the existing file.
+				 */
+				if (!librarySystemPath.exists()) {
+					throw e;
+				}
+			} finally {
+				input.close();
+			}
+		} else {
+			throw new IOException("Failed to read input stream for " + librarySystemPath.getCanonicalPath());
+		}
+	}
+
+	private static File discoverExtractLocation(String folderName, String fileName) throws IOException {
+
+		File path;
+
+		// system property
+
+		if (SHARED_LIBRARY_EXTRACT_PATH != null) {
+			path = new File(SHARED_LIBRARY_EXTRACT_PATH, fileName);
+			if (canWrite(path)) {
+				return path;
+			}
+		}
+
+		// Java tmpdir
+
+		path = new File(System.getProperty("java.io.tmpdir") + "/" + folderName, fileName);
+		if (canWrite(path)) {
+			return path;
+		}
+
+		// NIO temp file
+
+		try {
+			File file = File.createTempFile(folderName, null);
+			if (file.delete()) {
+				// uses temp file path as destination folder
+				path = new File(file, fileName);
+				if (canWrite(path)) {
+					return path;
+				}
+			}
+		} catch (IOException ignored) {
+
+		}
+
+		// user home
+
+		path = new File(System.getProperty("user.home") + "/." + folderName, fileName);
+		if (canWrite(path)) {
+			return path;
+		}
+
+		// working directory
+
+		path = new File(".tmp/" + folderName, fileName);
+		if (canWrite(path)) {
+			return path;
+		}
+
+		throw new IOException("No suitable extraction path found");
+	}
+
+	private static boolean canWrite(File file) {
+
+		File folder = file.getParentFile();
+
+		if (file.exists()) {
+			if (!file.canWrite() || !canExecute(file)) {
+				return false;
+			}
+		} else {
+			if (!folder.exists()) {
+				if (!folder.mkdirs()) {
+					return false;
+				}
+			}
+			if (!folder.isDirectory()) {
+				return false;
+			}
+		}
+
+		File testFile = new File(folder, UUID.randomUUID().toString());
+
+		try {
+			new FileOutputStream(testFile).close();
+			return canExecute(testFile);
+		} catch (IOException e) {
+			return false;
+		} finally {
+			testFile.delete();
+		}
+	}
+
+	private static boolean canExecute(File file) {
+
+		try {
+			if (file.canExecute()) {
+				return true;
+			}
+
+			if (file.setExecutable(true)) {
+				return file.canExecute();
+			}
+		} catch (Exception ignored) {
+
+		}
+
+		return false;
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 		<module>jnigen</module>
 		<module>loader/gdx</module>
 		<module>loader/lwjgl3</module>
+		<module>loader/legacy</module>
 		<module>server</module>
 		<module>tests</module>
 	</modules>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -51,6 +51,11 @@
 		</dependency>
 		<dependency>
 			<groupId>com.code-disaster.steamworks4j</groupId>
+			<artifactId>steamworks4j-legacy</artifactId>
+			<version>1.10.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>com.code-disaster.steamworks4j</groupId>
 			<artifactId>steamworks4j-server</artifactId>
 			<version>1.10.0-SNAPSHOT</version>
 		</dependency>

--- a/tests/src/main/java/com/codedisaster/steamworks/test/SteamTestApp.java
+++ b/tests/src/main/java/com/codedisaster/steamworks/test/SteamTestApp.java
@@ -263,6 +263,10 @@ public abstract class SteamTestApp {
 				loader = new SteamLibraryLoaderGdx();
 				break;
 			}
+			if (arg.equals("--legacy")) {
+				loader = new SteamLibraryLoaderLegacy();
+				break;
+			}
 		}
 
 		if (loader == null) {


### PR DESCRIPTION
Restores the mac & gradle compatible loader from previous versions as a legacy loader. Uses the new SteamLibraryLoader interface