### PR TITLE
Add arg pchIdentity in getAuthTicketForWebApi

### DIFF
--- a/java-wrapper/src/main/java/com/codedisaster/steamworks/SteamUser.java
+++ b/java-wrapper/src/main/java/com/codedisaster/steamworks/SteamUser.java
@@ -123,6 +123,17 @@ public class SteamUser extends SteamInterface {
 		return new SteamAuthTicket(ticket);
 	}
 
+	public SteamAuthTicket getAuthTicketForWebApi(String pchIdentity) {
+		// gdx jnigen does not work with nullable strings
+		int ticket;
+		if (pchIdentity == null) {
+			ticket = SteamUserNative.getAuthTicketForWebApi();
+		} else {
+			ticket = SteamUserNative.getAuthTicketForWebApi(pchIdentity);
+		}
+		return new SteamAuthTicket(ticket);
+	}
+
 	public SteamAuth.BeginAuthSessionResult beginAuthSession(ByteBuffer authTicket, SteamID steamID) throws SteamException {
 
 		if (!authTicket.isDirect()) {

--- a/java-wrapper/src/main/java/com/codedisaster/steamworks/SteamUserNative.java
+++ b/java-wrapper/src/main/java/com/codedisaster/steamworks/SteamUserNative.java
@@ -71,6 +71,11 @@ final class SteamUserNative {
 		return ticket;
 	*/
 
+	static native int getAuthTicketForWebApi(String pchIdentity); /*
+		int ticket = SteamUser()->GetAuthTicketForWebApi(pchIdentity);
+		return ticket;
+	*/
+
 	static native int beginAuthSession(ByteBuffer authTicket,
 									   int bufferOffset, int bufferSize, long steamID); /*
 		return SteamUser()->BeginAuthSession(&authTicket[bufferOffset], bufferSize, (uint64) steamID);


### PR DESCRIPTION
This pchIdentity value is essential for security in any p2p games.

Overloads the function in SteamUser, and SteamUserNative because jnigen does not support nullable strings as inputs.