### PR TITLE
Fix SteamLibraryLoaderGdx on macOS

### DIFF
--- a/loader/gdx/src/main/java/com/codedisaster/steamworks/SteamLibraryLoaderGdx.java
+++ b/loader/gdx/src/main/java/com/codedisaster/steamworks/SteamLibraryLoaderGdx.java
@@ -55,6 +55,14 @@ public class SteamLibraryLoaderGdx implements SteamLibraryLoader {
 			}
 		}
 
+		/**
+		 * Behind the scenes SharedLibraryLoader extracts libraries from resources
+		 * into separate directories based on the CRC checksum of the files.
+		 * When loading libsteamworks4j.dylib, libsteam_api.dylib needs to be in
+		 * the same directory due to the install-name of libsteam_api.dylib.
+		 * <p>
+		 * This override forces all extracted libraries into the same directory.
+		 */
 		@Override
 		public String crc(InputStream input) {
 			closeQuietly(input);

--- a/loader/gdx/src/main/java/com/codedisaster/steamworks/SteamLibraryLoaderGdx.java
+++ b/loader/gdx/src/main/java/com/codedisaster/steamworks/SteamLibraryLoaderGdx.java
@@ -2,6 +2,7 @@ package com.codedisaster.steamworks;
 
 import com.badlogic.gdx.utils.SharedLibraryLoader;
 
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -52,6 +53,12 @@ public class SteamLibraryLoaderGdx implements SteamLibraryLoader {
 				}
 				super.load(libraryName);
 			}
+		}
+
+		@Override
+		public String crc(InputStream input) {
+			closeQuietly(input);
+			return "00000000";
 		}
 	};
 

--- a/loader/gdx/src/main/java/com/codedisaster/steamworks/SteamLibraryLoaderGdx.java
+++ b/loader/gdx/src/main/java/com/codedisaster/steamworks/SteamLibraryLoaderGdx.java
@@ -65,8 +65,11 @@ public class SteamLibraryLoaderGdx implements SteamLibraryLoader {
 		 */
 		@Override
 		public String crc(InputStream input) {
-			closeQuietly(input);
-			return "00000000";
+			if (isMac) {
+				closeQuietly(input);
+				return "00000000";
+			}
+			return super.crc(input);
 		}
 	};
 


### PR DESCRIPTION
Behind the scenes, the libgdx loader extracts `libsteam_api.dylib` and `libsteamworks4j.dylib` into separate directories based on the CRC checksum of their contents.
Unfortunately, `libsteam_api.dylib` has an install name of `@loader_path/libsteam_api.dylib`.
When loading `libsteamworks4j.dylib` it expects `libsteam_api.dylib` to be in the same directory.

This patch hardcodes the result of `crc()` to `00000000`. As a result, both libraries will be extracted inside `<libgdx-path>/00000000/` and libsteamworks4j.dylib loads successfully.
